### PR TITLE
Fix bug when transitioning to stopped state

### DIFF
--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1699,8 +1699,10 @@ def change_instance_state(filters, desired_module_state):
                 # 'pending'
                 if inst['State']['Name'] == 'pending':
                     await_instances([inst['InstanceId']], desired_module_state='running', force_wait=True)
+                elif inst['State']['Name'] == 'stopping':
+                    await_instances([inst['InstanceId']], desired_module_state='stopped', force_wait=True)
                 # Already moving to the relevant state
-                elif inst['State']['Name'] in ('stopping', 'stopped'):
+                elif inst['State']['Name'] == 'stopped':
                     unchanged.add(inst['InstanceId'])
                     continue
 


### PR DESCRIPTION
## Overview

If our desired state of `ec2` instance is `stopped` and it is already `stopping` then we should wait for it to transition, before continuing.
Otherwise the instance can be left in `stopping` state after the module finishes.

## Reproducing the issues

I've prepared sample playbook that shows the issue:
``` ansible
---
- name: Create EC2 instance
  hosts: localhost
  connection: local
  gather_facts: no

  vars:
    instance_type: t2.micro
    image: ami-0c94855ba95c71c99
    key_name: kkaminski
    region: us-east-1
    group_name: test-security-group
    count: 1
    vpc_id: vpc-59f5713c
    subnet_id: subnet-dc955185

  tasks:
  - name: Create security group
    ec2_group:
      vpc_id: "{{ vpc_id }}"
      name: "{{ group_name }}"
      description: "Security group for EC2 instance"
      region: "{{ region }}"
  - name: Launch EC2 instance
    amazon.aws.ec2_instance:
      key_name: "{{ key_name }}"
      security_group: "{{ group_name }}"
      instance_type: "{{ instance_type }}"
      image_id: "{{ image }}"
      vpc_subnet_id: "{{ subnet_id }}"
      wait: true
      count: "{{ count }}"
      region: "{{ region }}"
      tags:
        Name: "Test instance"
    register: ec2

  - name: Initiate instance stopping
    amazon.aws.ec2_instance:
      instance_ids: ["{{ ec2.instances[0].instance_id }}"]
      wait: false
      state: stopped
      region: "{{ region }}"

  - name: Try to stop it again
    amazon.aws.ec2_instance:
      instance_ids: ["{{ ec2.instances[0].instance_id }}"]
      wait: true
      state: stopped
      region: "{{ region }}"
```

Step `Try to stop it again` will fail with below error:
```
TASK [Try to stop it again] ***************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => changed=false 
  msg: 'Unable to stop instances: '
  stop_failed:
  - i-0bd43a6904aeffe73
  stop_success: []

PLAY RECAP ********************************************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```
This error appears since we can't stop instance which is already `stopping`.

Fix to that is to simply wait until `stopping` instance fully stops.